### PR TITLE
update frontend challenge for GO.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Pick the one that most suites the position you wish to apply.
 **Trading Exchange**
 
 * Backend / Elixir [exchange-challenge](https://gist.github.com/theesit-omise/26abab54487996d9702535421b459858)
-* Frontend / React - [tamboon-react](https://github.com/omise/challenges/tree/challenge-react)
+* Frontend / React - [tamboon-react](https://github.com/theesit-omise/challenges/tree/challenge-react)
 * Backend / Go - [go-challenge](https://github.com/omise/challenges/tree/challenge-go)
 
 **OmiseGO**


### PR DESCRIPTION
I changed Frontend challenge to point to Go.X frontend challenge. 

In Go.X, we will set expectation to candidate that we are really focus on unit tests explicitly.
