### PR TITLE
Follow redirect in random charity test

### DIFF
--- a/test/integration/website_test.rb
+++ b/test/integration/website_test.rb
@@ -81,6 +81,7 @@ class WebsiteTest < ActionDispatch::IntegrationTest
     post(donate_path, params: {
            amount: "100", omise_token: "tokn_X", charity: "random"
          })
+    follow_redirect!
 
     assert_template :index
     assert_equal expected_total, charities.to_a.map(&:reload).sum(&:total)


### PR DESCRIPTION
In one of the test related to random charity donation, we need to add `follow_redirect!` after posting. Otherwise the index view won't be rendered and the test will fail.